### PR TITLE
Prevent a BoundsError

### DIFF
--- a/src/guesstype.jl
+++ b/src/guesstype.jl
@@ -315,7 +315,7 @@ function guesstype( ex, ctx::LintContext )
         try
             elt = eval( Main, ex.args[2] )
         end
-        if sig[1] == DataType
+        if length(sig) >= 1 && sig[1] == DataType
             if length(sig) == 2 && isexpr(ex.args[3],:tuple)
                 ret = Array{ elt, length(ex.args[3].args ) }
             elseif length(sig) == 2 && sig[2] <: Tuple && all( x->x <: Integer, sig[2] )


### PR DESCRIPTION
When guessing the type of a call to zeros() or ones() without arguments, a BoundsError is raised.

Test case:
    $ echo "x = zeros()" > temp.jl
    $ julia -E 'using Lint; lintfile("temp.jl")'